### PR TITLE
Update to Platform 21.08 and libgdiplus 6.1

### DIFF
--- a/com.jaquadro.NBTExplorer.desktop
+++ b/com.jaquadro.NBTExplorer.desktop
@@ -4,4 +4,4 @@ Comment=A graphical NBT editor for all Minecraft NBT data sources
 Exec=nbtexplorer
 Type=Application
 Icon=com.jaquadro.NBTExplorer
-Categories=Game;
+Categories=Game;Utility;

--- a/com.jaquadro.NBTExplorer.yml
+++ b/com.jaquadro.NBTExplorer.yml
@@ -1,6 +1,6 @@
 app-id: com.jaquadro.NBTExplorer
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.mono6
@@ -23,8 +23,8 @@ modules:
   - name: libgdiplus
     sources:
       - type: archive
-        url: https://download.mono-project.com/sources/libgdiplus/libgdiplus0-5.6.1.tar.gz
-        sha256: 78624f268fae77ba391037fe0c8c804924e8e9f94d4ca9a9dd5610d694cf9014
+        url: https://download.mono-project.com/sources/libgdiplus/libgdiplus-6.1.tar.gz
+        sha256: 97d5a83d6d6d8f96c27fb7626f4ae11d3b38bc88a1726b4466aeb91451f3255b
   - name: nbtexplorer
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This moves NBTExplorer to a supported platform SDK as well as a much more recent version of libgdiplus. While the package currently uses libgdiplus0 5.6.1 with platform 19.08, I encountered build errors when trying to use the same version with either platform 20.08 or 21.08. While the build succeeded when using libgdiplus0 6.0.5 (latest I could find), there were unexpected visual glitches in the app's interface that I noticed when opening a level.dat file for a Minecraft world (primarily, icons not rendering in the main view). Building with libgdiplus 6.1 resolved this, however I'm personally unaware of what the differences between libgdiplus0 and libgdiplus are and thus am unaware of what reasoning there was behind using the former initially; changes may be required in the event that this results in regressions.

Additionally, I have added the change suggested in #1 as it does better describe the use case of this application, while keeping the "Game" category given that the usecase is specific to a game.