### PR TITLE
Freedesktop 24.08 and GTK2 fix for GCC 14.x

### DIFF
--- a/com.jaquadro.NBTExplorer.yml
+++ b/com.jaquadro.NBTExplorer.yml
@@ -1,6 +1,6 @@
 app-id: com.jaquadro.NBTExplorer
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.mono6


### PR DESCRIPTION
This PR addresses both an issue building the GTK2 dependency in environments with GCC 14 (by updating the shared-modules submodule to [a711ceb](https://github.com/flathub/shared-modules/tree/a711ceb522af312491ddfb4058c17a944772d0d8)) and the Freedesktop Platform runtime 21.08 being EOL (by updating to 24.08).
Fixes #3