### PR TITLE
Fix .minecraft detection by setting APPDATA

### DIFF
--- a/com.jaquadro.NBTExplorer.yml
+++ b/com.jaquadro.NBTExplorer.yml
@@ -43,7 +43,7 @@ modules:
       - type: script
         dest-filename: nbtexplorer
         commands:
-          - exec mono /app/share/nbtexplorer/NBTExplorer.exe
+          - APPDATA=$HOME exec mono /app/share/nbtexplorer/NBTExplorer.exe
       - type: file
         path: com.jaquadro.NBTExplorer.png
       - type: file


### PR DESCRIPTION
Needs testing, but running `APPDATA=$HOME flatpak run com.jaquadro.NBTExplorer` did the trick and this *seems* right. This might seem hacky, but NBTExplorer uses APPDATA exclusively for locating .minecraft. Hopefully it does not change the behaviour of any of the libraries it uses.