### PR TITLE
Build from source

### DIFF
--- a/com.jaquadro.NBTExplorer.yml
+++ b/com.jaquadro.NBTExplorer.yml
@@ -28,18 +28,22 @@ modules:
   - name: nbtexplorer
     buildsystem: simple
     build-commands:
+      - /usr/lib/sdk/mono6/bin/msbuild
       - install -D nbtexplorer /app/bin/nbtexplorer
-      - install -D NBTExplorer.exe /app/share/nbtexplorer/NBTExplorer.exe
-      - install -D NBTExplorer.exe.config /app/share/nbtexplorer/NBTExplorer.exe.config
-      - install -D Substrate.dll /app/share/nbtexplorer/Substrate.dll
-      - install -D NBTModel.dll /app/share/nbtexplorer/NBTModel.dll
+      - install -D Staging/NBTExplorer.exe /app/share/nbtexplorer/NBTExplorer.exe
+      - install -D Staging/NBTExplorer.exe.config /app/share/nbtexplorer/NBTExplorer.exe.config
+      - install -D Staging/Substrate.dll /app/share/nbtexplorer/Substrate.dll
+      - install -D Staging/NBTModel.dll /app/share/nbtexplorer/NBTModel.dll
       - install -D com.jaquadro.NBTExplorer.desktop /app/share/applications/com.jaquadro.NBTExplorer.desktop
       - install -D com.jaquadro.NBTExplorer.png /app/share/icons/hicolor/128x128/apps/com.jaquadro.NBTExplorer.png
       - install -D com.jaquadro.NBTExplorer.metainfo.xml /app/share/metainfo/com.jaquadro.NBTExplorer.metainfo.xml
     sources:
-      - type: archive
-        url: https://github.com/jaquadro/NBTExplorer/releases/download/v2.8.0-win/NBTExplorer-2.8.0.zip
-        sha256: 1bf4c3e56a0e8fba911c6c73cc12fbf105c01367d92dcfb9d20b0f529a666e4b
+      - type: git
+        url: https://github.com/jaquadro/NBTExplorer.git
+        tag: v2.8.0-win
+        commit: d29f249d7e489eaa4ccf8ba5b661cfa6ae0466ff
+      - type: patch
+        path: patches/fix-msbuild.patch
       - type: script
         dest-filename: nbtexplorer
         commands:

--- a/patches/fix-msbuild.patch
+++ b/patches/fix-msbuild.patch
@@ -1,0 +1,24 @@
+diff --git a/NBTExplorer.sln b/NBTExplorer.sln
+index 23056e7..93bdc52 100644
+--- a/NBTExplorer.sln
++++ b/NBTExplorer.sln
+@@ -5,19 +5,10 @@ VisualStudioVersion = 14.0.23107.0
+ MinimumVisualStudioVersion = 10.0.40219.1
+ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBTExplorer", "NBTExplorer\NBTExplorer.csproj", "{8A458245-8176-4599-95CD-3CA39F2435CE}"
+ EndProject
+-Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "NBTExplorer.Installer", "NBTExplorer.Installer\NBTExplorer.Installer.wixproj", "{A1566071-7CBB-4C54-AAE1-4B81B7715DB3}"
+-	ProjectSection(ProjectDependencies) = postProject
+-		{8A458245-8176-4599-95CD-3CA39F2435CE} = {8A458245-8176-4599-95CD-3CA39F2435CE}
+-		{20D7CBA3-5B6D-40B0-8D28-4C9A58E4FFBC} = {20D7CBA3-5B6D-40B0-8D28-4C9A58E4FFBC}
+-		{BD90EED5-97B9-47D5-AFEA-C2C0D0E59FCF} = {BD90EED5-97B9-47D5-AFEA-C2C0D0E59FCF}
+-	EndProjectSection
+-EndProject
+ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBTUtil", "NBTUtil\NBTUtil.csproj", "{BD90EED5-97B9-47D5-AFEA-C2C0D0E59FCF}"
+ EndProject
+ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBTModel", "NBTModel\NBTModel.csproj", "{20D7CBA3-5B6D-40B0-8D28-4C9A58E4FFBC}"
+ EndProject
+-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Substrate (NET2)", "..\Substrate\SubstrateCS\Substrate (NET2).csproj", "{AFE30E14-3F2F-4461-9F7D-147AB4DCA4C3}"
+-EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		AppStore|Any CPU = AppStore|Any CPU


### PR DESCRIPTION
Currently the flatpak is built from the prebuilt binaries, distributed by the application author on github releases, even though the app is open source.

Since there are no technical reasons to do that, build it from source using msbuild, which requires patching the project solution file.